### PR TITLE
Included Unity Package definition

### DIFF
--- a/GlobalstatsIO.cs.meta
+++ b/GlobalstatsIO.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9c2dead7ebb8c73419d370c3448c3484
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,28 @@ If you are looking for a .Net implementation that you can also use in Unity you 
 ## Usage
 Simply add the .cs file to your project.
 
+OR
+
+Include this repository as a package:
+- In Unity 2021+
+    1. Open the Package Manager (Window -> Package Manager).
+    2. Click the plus sign button ("+") and select "Add package from git URL..."
+    3. Enter the URL of this repository and click "Add".
+- In previous versions, add the following line to your Packages/manifest.json file under dependencies:
+
+    ```
+    "io.gitstats.unity": "URL of this repo"
+    ```
+
+To get the URL of this repository to use in any of the options above, click on the green "Code" button at the top of this page, then copy the HTTPS URL.
+
 ### Submitting Scores
-To submit a player score instatiante a object, add the values and call Share()
+To submit a player score instantiate a object, add the values and call Share()
 ```
 private const string GlobalstatsIOApiId = "YourApiIdHere";
 private const string GlobalstatsIOApiSecret = "YourApiSecretHere";
 
-GlobalstatsIO gs = new GlobalstatsIO(GlobalstatsIOApiId, GlobalstatsIOApiSecret);
+var gs = new GlobalstatsIOClient(GlobalstatsIOApiId, GlobalstatsIOApiSecret);
 
 string user_name = "Nickname";
 
@@ -66,7 +81,7 @@ void CallbackMethod(bool success){
 ```
 Of course, this will use the data from the prior share() call for linking.
 
-### Retrieving Leaderboard 
+### Retrieving Leaderboard
 You can also fetch the current top positions of your leaderboard with a GTD of your choice. You can retrieve that leaderboard with following lines:
 
 ```
@@ -86,7 +101,7 @@ void CallbackMethod(Leaderboard leaderboard){
 }
 ```
 
-In this case we want the leaderboard of the GTD score. The limit is the number players you want to fetch, which has to be between 1 and 100. 
+In this case we want the leaderboard of the GTD score. The limit is the number players you want to fetch, which has to be between 1 and 100.
 
 ## Feedback
 If you encounter any issues you can create an issue here on github.

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4d2a9fbc819168c44ab5a5fdcebb8999
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/io.globalstats.unity.asmdef
+++ b/io.globalstats.unity.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "io.globalstats.unity",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/io.globalstats.unity.asmdef.meta
+++ b/io.globalstats.unity.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: deff98c6e4262274794bb4bd6d5c6887
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "io.globalstats.unity",
+  "version": "1.0.0",
+  "displayName": "GlobalStats",
+  "description": "The integration of the globalstats.io API into a library for unity",
+  "unity": "2018.4",
+  "author": {
+    "name": "globalstats.io",
+    "email": "feedback@globalstats.io",
+    "url": "https://globalstats.io/"
+  }
+}

--- a/package.json.meta
+++ b/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9ef87eb9f3b21c842a38e6b5982a706a
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The changes made in this PR don't touch the code in the library.

Instead, the files included offer the possibility to include the library in any Unity project as a package using the Package Manager, and avoiding the need to manually download and import the CS file; later changes made in the library can be pulled easily using the Package Manager (again, no need to come back to the repo, download, and import).

As a brief summary of the changes:
- The `package.json` file describes the package and it's the one that actually allows importing the whole repository as a Unity Package using only the GitHub URL of the repository. 
- The `io.globalstats.unity.asmdef` file forces the script (or scripts if the library had more than 1) to be precompiled in its own assembly when it's imported, so when users make changes to their own code, this library is not recompiled each time. Besides, it's required by the Package Manager to make the library a package.
- In the README file, I added instructions on how to use the Package Manager in different versions of Unity to import the project... and additionally I fixed a code example that had a mistyped class name.

It's worth noting that even with these changes, users can still grab the cs file directly from the repo and manually import it, as they've been doing until now, if they want; only they'll lose the benefits described above.